### PR TITLE
Show the service url; make the whole status area clickable

### DIFF
--- a/src/components/Response.jsx
+++ b/src/components/Response.jsx
@@ -3,10 +3,10 @@ import '../css/response.css';
 
 export default class ServiceResponse extends React.Component {
     constructor(props) {
-        super(props)
+        super(props);
         this.state = {
             view: false
-        }
+        };
     }
 
     updateResponse(response) {
@@ -31,7 +31,11 @@ export default class ServiceResponse extends React.Component {
             return <div></div>
         }
         const response = this.updateResponse(this.props.response);
-        console.log(response);
-        return <pre className="response-area">{response}</pre>
+        return (
+            <>
+              <p className="response-url"> {this.props.url} </p>
+              <pre className="response-area">{response}</pre>
+            </>
+        );
     }
 }

--- a/src/components/Status.jsx
+++ b/src/components/Status.jsx
@@ -67,13 +67,13 @@ export default function Status(props) {
 
     return (
         <div className={`kb-service-status ${status}`}>
-            <div className="status-flex">
+            <div className="status-flex" onClick={toggleResponseView}>
                 <div>{props.name}</div>
-                <a onClick={toggleResponseView} className="status-button">
+                <a className="status-button">
                     <StatusIcon status={status}/>
                 </a>
             </div>
-            <ServiceResponse view={responseView} response={response} />
+            <ServiceResponse view={responseView} response={response} url={props.url} />
         </div>
     );
 }

--- a/src/css/App.css
+++ b/src/css/App.css
@@ -18,6 +18,7 @@
 }
 
 .status-area {
+  margin-top: 2rem;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/css/response.css
+++ b/src/css/response.css
@@ -3,3 +3,8 @@
     font-size: smaller;
     overflow: auto;
 }
+
+.response-url {
+    font-size: 1.15rem;
+    font-family: monospace;
+}

--- a/src/css/status.css
+++ b/src/css/status.css
@@ -22,11 +22,6 @@
 
 .status-button {
     margin-left: auto;
-    cursor: pointer;
-}
-
-.status-button:hover {
-    filter: brightness(70%);
 }
 
 .icon-ok {
@@ -42,5 +37,11 @@
 }
 
 .status-flex {
+    cursor: pointer;
     display: flex;
+    transition: opacity 0.1s linear;
+}
+
+.status-flex:hover {
+    opacity: 0.65;
 }


### PR DESCRIPTION
I just wanted an easy way to see every service URL here. They are shown above the status response.
Also thought it would be nice to be able to click the whole status section to expand it rather than just the icon.